### PR TITLE
Fix deprecated warnings

### DIFF
--- a/init.php
+++ b/init.php
@@ -29,10 +29,6 @@ class ff_Instagram extends Plugin
 	}
 
 	function init($host) {
-		if (version_compare(VERSION_STATIC, '1.12', '<=') && VERSION_STATIC === VERSION){
-			user_error('Hooks not registered. Needs trunk or version > 1.12', E_USER_NOTICE);
-			return;
-		}
 		$host->add_hook($host::HOOK_FETCH_FEED, $this);
 		$host->add_hook($host::HOOK_FEED_FETCHED, $this);
 		$host->add_hook($host::HOOK_SUBSCRIBE_FEED, $this);

--- a/init.php
+++ b/init.php
@@ -146,12 +146,13 @@ class ff_Instagram extends Plugin
 		self::check_feed_icon($user->icon_url(), $feed_id);
 
 		//check latest entry in DB
-		$result = $db->query("SELECT max(date_entered) AS ts FROM
+		$sth = $db->prepare("SELECT max(date_entered) AS ts FROM
 				ttrss_entries, ttrss_user_entries WHERE
-				ref_id = id AND feed_id = '$feed_id'", false);
-		$ts = $db->fetch_result($result, 0, "ts");  // NULL when no entries in DB
+				ref_id = id AND feed_id = ?");
+		$sth->execute([$feed_id]);
+		$db_row = $sth->fetch();
 
-		if($ts) $ts = @strtotime($ts);
+		if($sth->rowCount() > 0) $ts = @strtotime($db_row["ts"]);
 		else $ts = false;
 
 		return [$feed->saveXML(), $ts];
@@ -227,7 +228,7 @@ class ff_Instagram extends Plugin
 			return "";
 		}
 
-		list($con, $this->ts) = self::create_xml_icon_stamp($this->user, $feed_id, $this->host->get_dbh());
+		list($con, $this->ts) = self::create_xml_icon_stamp($this->user, $feed_id, $this->pdo);
 
 		return $con;
 	}
@@ -253,7 +254,7 @@ class ff_Instagram extends Plugin
 			return "<error>'$url': {$e->getMessage()}</error>\n";
 		}
 
-		list($con, $this->ts) = self::create_xml_icon_stamp($this->user, $feed_id, $this->host->get_dbh());
+		list($con, $this->ts) = self::create_xml_icon_stamp($this->user, $feed_id, $this->pdo);
 
 		return $con;
 	}

--- a/instagram.php
+++ b/instagram.php
@@ -825,7 +825,7 @@ class UserPage {
 		while($mediaid > 0){
 			$remainder = $mediaid % 64;
 			$mediaid = ($mediaid-$remainder) / 64;
-			$shortcode = $alphabet{$remainder} . $shortcode;
+			$shortcode = $alphabet[$remainder] . $shortcode;
 		};
 
 		return $shortcode;


### PR DESCRIPTION
I removed the check for version >= 1.12 as this version is over 5 years old and hopefully nobody is using it anymore anyway.
This also includes my earlier pull request but now rebased to master.